### PR TITLE
Users will not expect this

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KO_DOCKER_REPO ?= kingdonb
 TAG ?= latest
 
-all: tidy build kube.config
+all: tidy build
 
 install: tidy build
 	go install github.com/kingdon-ci/kubeconfig-ca-fetch/cmd/kubeconfig-ca-fetch@latest


### PR DESCRIPTION
Don't run the program, only build when "make"

In the current workflow if you type `make` then you are probably surprised that the program runs, and output is created in `kube.config` -- I wasn't prepared for that, and I am the one that wrote this. So I'm taking this out.

Run `make tldr` or if you want to overwrite your kubeconfig run `make supertldr`, but you might need to run `make clean` first.

```
make clean && make && make supertldr
```

^ is what the CI environment or health check should probably run, if it's non-ephemeral and needs to clean up after itself in the sandbox.