### PR TITLE
Add talos-dev

### DIFF
--- a/cmd/kubeconfig-ca-fetch/main.go
+++ b/cmd/kubeconfig-ca-fetch/main.go
@@ -28,6 +28,7 @@ func main() {
 		},
 	}
 	m := map[string]string{
+		"talos-dev":      "10.17.12.105:6443",
 		"botkube-demo":   "botkube-demo.turkey.local",
 		"cluster-01":     "cluster-01.turkey.local",
 		"cluster-02":     "cluster-02.turkey.local",


### PR DESCRIPTION
There is a new talos-dev cluster with one control plane node and no VIP

This is non-production, but it may replace the existing management cluster (🤞)

It is configured for OIDC like the rest of these clusters using the weave gitops dex instance, since that Weave GitOps cluster is still online, that's fine.

We may need to migrate to something later, but for now this solves the chicken and egg problem nicely, meaning that the control plane apiServer will not come up if Dex isn't up, (so Dex for the cluster itself can't reasonably be hosted on the cluster itself) - we can just say "weave gitops" and the chicken-and-egg problem goes away.

Never mind GitopsCluster / ClusterBootstrapConfig / how do these things happen in order - we have an engineer running `flux bootstrap` on every new cluster, and this is perfect. There's no need to automate things further. An admin blesses every install, and if a production service is ever running on something called "talos-dev" you get three demerits instantly.

This is not prod 🤞 